### PR TITLE
AutoMLの最適化指標対応とバックテスト報告生成を追加

### DIFF
--- a/src/data/processors/technical_indicators.py
+++ b/src/data/processors/technical_indicators.py
@@ -31,6 +31,7 @@ class TechnicalIndicators:
             # トレンド系指標
             df = TechnicalIndicators.add_sma(df, periods=[5, 10, 20, 50, 200])
             df = TechnicalIndicators.add_ema(df, periods=[5, 10, 20, 50, 200])
+            df = TechnicalIndicators.add_wma(df, period=20)
             df = TechnicalIndicators.add_macd(df)
             df = TechnicalIndicators.add_bollinger_bands(df)
 
@@ -52,6 +53,11 @@ class TechnicalIndicators:
             # 価格変化
             df = TechnicalIndicators.add_returns(df)
             df = TechnicalIndicators.add_log_returns(df)
+
+            # パターン・その他指標
+            df = TechnicalIndicators.add_candlestick_patterns(df)
+            df = TechnicalIndicators.add_pivot_points(df)
+            df = TechnicalIndicators.add_price_channels(df)
 
             logger.info(f"Added {len(df.columns) - 6} technical indicators")  # 6はOHLCV+date
 

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from src.data.processors.sentiment_analyzer import SentimentAnalyzer
 from src.models.ml_models import XGBoostModel, evaluate_model
 from src.models.automl import AutoMLPipeline
 from src.backtesting.backtest_engine import BacktestEngine
+from src.backtesting.report_generator import ReportGenerator
 from src.gui.main_window import launch_gui
 from src.gui.main_window_enhanced import launch_enhanced_gui
 
@@ -179,6 +180,15 @@ def backtest_workflow(symbol: str, logger):
     logger.info(f"  Max Drawdown: {results['max_drawdown_pct']:.2f}%")
     logger.info(f"  Win Rate: {results['win_rate_pct']:.2f}%")
     logger.info(f"  Number of Trades: {results['num_trades']}")
+
+    report_format = get_config('reports.default_format', 'excel')
+    report_generator = ReportGenerator()
+    if report_format == 'pdf':
+        report_path = report_generator.generate_backtest_report_pdf(results, symbol)
+    else:
+        report_path = report_generator.generate_backtest_report_excel(results, symbol)
+    if report_path:
+        logger.info(f"Backtest report generated: {report_path}")
 
     return results
 

--- a/src/models/ml_models.py
+++ b/src/models/ml_models.py
@@ -193,7 +193,7 @@ class RandomForestModel(BaseModel):
 
         self.model = RandomForestRegressor(**params)
 
-    def train(self, X_train, y_train, X_val=None, y_val=None):
+    def train(self, X_train, y_train, X_val=None, y_val=None, **kwargs):
         """モデルを訓練"""
         self.logger.info("Training Random Forest model...")
 


### PR DESCRIPTION
### Motivation
- `AutoML`で最適化メトリクスを設定可能にして最小化／最大化の挙動を柔軟に切替できるようにするため。 
- Optuna最適化でモデル初期化や最適化実行時のパラメータ受け渡しの不整合を修正するため。 
- デフォルトの特徴量セットを拡張してモデル入力の情報量を増やすため。 
- CLIバックテスト実行時に自動でレポートを生成するワークフローを追加するため。

### Description
- `AutoML`に`_get_metric_settings`と`_calculate_metric`を追加し、`config['metric']`に基づいてメトリクス名と`direction`を決定するようにした。 
- Optunaの`objective`内およびモデル選択処理でモデルを`XGBoostModel(**params)`/`LightGBMModel(**params)`/`RandomForestModel(**params)`として初期化するよう修正し、`optimization_timeout`を`study.optimize`に渡すようにした。 
- モデル比較後の評価で使用するメトリクス計算をメトリクス設定に合わせて`_calculate_metric`経由で行うようにした。 
- `TechnicalIndicators.add_all_indicators`に`WMA`、`candlestick_patterns`、`pivot_points`、`price_channels`の追加を行いデフォルト指標を拡張した。 
- `backtest_workflow`に`ReportGenerator`の呼び出しを追加し、`reports.default_format`に応じてExcelまたはPDFのバックテストレポートを生成する処理を追加した。 
- `RandomForestModel.train`に`**kwargs`を追加して余分な引数を受け取っても問題にならないようにした。 
- 使用されなくなった`cross_val_score`のインポートを削除した。

### Testing
- 自動テストは実行しておらず、ユニットテストやCIによる検証は行っていません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ddcf9a2dc832f9d559beb5e437c01)